### PR TITLE
Add support for Django REST Framework's `Request.data`

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -20,7 +20,7 @@ runs:
       python -m pip install --upgrade pip
       if [[ ${{ inputs.django-version }} != 'main' ]]; then pip install --pre -q "Django>=${{ inputs.django-version }},<${{ inputs.django-version }}.99"; fi
       if [[ ${{ inputs.django-version }} == 'main' ]]; then pip install https://github.com/django/django/archive/main.tar.gz; fi
-      pip install flake8 django-redis pymemcache
+      pip install flake8 django-redis pymemcache djangorestframework
 
   - name: Test
     shell: sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 
 This version includes [django-ratelimit](https://github.com/jsocol/django-ratelimit) v4.1.0
 
+- Add support rate limiting on the key `data` for use with Django REST Framework's [`Request.data`](https://www.django-rest-framework.org/api-guide/requests/#data)
 - Fix duplicated option issue in `tox.ini`

--- a/django_ratelimit/core.py
+++ b/django_ratelimit/core.py
@@ -1,3 +1,6 @@
+# NOTE: This file originally from django-ratelimit has been edited
+# to add support for Django REST Framework's `Request.data`
+
 import ipaddress
 import functools
 import hashlib
@@ -81,6 +84,7 @@ def get_header(request, header):
 _ACCESSOR_KEYS = {
     'get': lambda r, k: r.GET.get(k, ''),
     'post': lambda r, k: r.POST.get(k, ''),
+    'data': lambda r, k: r.data.get(k, ''),
     'header': get_header,
 }
 

--- a/django_ratelimit/tests.py
+++ b/django_ratelimit/tests.py
@@ -7,6 +7,10 @@ from django.test.utils import override_settings
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+
 from django_ratelimit.decorators import ratelimit
 from django_ratelimit.exceptions import Ratelimited
 from django_ratelimit.core import (get_usage, is_ratelimited,
@@ -14,6 +18,7 @@ from django_ratelimit.core import (get_usage, is_ratelimited,
 
 
 rf = RequestFactory()
+rest_rf = APIRequestFactory()
 
 
 class MockUser:
@@ -151,6 +156,17 @@ class RatelimitTests(TestCase):
         assert view(rf.post('/', {'foo': 'a'}))
         assert not view(rf.post('/', {'foo': 'b'}))
         assert view(rf.post('/', {'foo': 'b'}))
+
+    def test_key_data(self):
+        @api_view(['POST'])
+        @ratelimit(key='data:foo', rate='1/m', block=False)
+        def view(request):
+            return Response(request.limited)
+
+        assert not view(rest_rf.post('/', {'foo': 'a'})).data
+        assert view(rest_rf.post('/', {'foo': 'a'})).data
+        assert not view(rest_rf.post('/', {'foo': 'b'})).data
+        assert view(rest_rf.post('/', {'foo': 'b'})).data
 
     def test_key_header(self):
         def _req():

--- a/test_settings.py
+++ b/test_settings.py
@@ -3,6 +3,9 @@ SECRET_KEY = 'ratelimit'
 SILENCED_SYSTEM_CHECKS = ['django_ratelimit.E003', 'django_ratelimit.W001']
 
 INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'rest_framework',
     'django_ratelimit',
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
+    djangorestframework~=3.15.1
     pymemcache>=4.0,<5.0
     django-redis>=5.2,<6.0
     flake8


### PR DESCRIPTION
Support rate limiting on the key `data` for use with Django REST Framework's [`Request.data`](https://www.django-rest-framework.org/api-guide/requests/#data)